### PR TITLE
feat: Finish Get new connection Form (to integrate new app) feature

### DIFF
--- a/app/controllers/connections_controller.rb
+++ b/app/controllers/connections_controller.rb
@@ -1,0 +1,38 @@
+class ConnectionsController < ApplicationController
+  def index
+  end
+
+  def show
+  end
+
+  def new
+    @app = App.find(params[:app_id])
+    @conn = Connection.new
+    @cred = @conn.creds.build
+    case @app.name
+    when "Datadog"
+      @cred.datadogs.build
+    when "Sendgrid"
+      @cred.sendgrids.build
+    end
+  end
+
+  def create
+    abort connection_params.inspect
+  end
+
+  private
+  def connection_params
+    params.require(:connection).permit(
+      connection_attributes: [
+      :app_id,
+      :app_type,
+      creds_attributes: [
+        :label,
+        datadogs_attributes: [ :api_key, :application_key, :subdomain ],
+        sendgrids_attributes: [ :api_key, :subuser ]
+        ]
+      ]
+    )
+  end
+end

--- a/app/controllers/connections_controller.rb
+++ b/app/controllers/connections_controller.rb
@@ -8,31 +8,36 @@ class ConnectionsController < ApplicationController
   def new
     @app = App.find(params[:app_id])
     @conn = Connection.new
-    @cred = @conn.creds.build
+    @cred = @conn.build_cred
     case @app.name
     when "Datadog"
-      @cred.datadogs.build
+      @cred.build_datadog
     when "Sendgrid"
-      @cred.sendgrids.build
+      @cred.build_sendgrid
     end
   end
 
   def create
-    abort connection_params.inspect
+    @app = App.find(params[:app_id])
+    # abort connection_params.inspect
+    @conn = Connection.create(connection_params)
+    if @conn.save
+      redirect_to @conn
+    else
+      render :new, status: :unprocessable_entity
+    end
   end
 
   private
   def connection_params
     params.require(:connection).permit(
-      connection_attributes: [
       :app_id,
-      :app_type,
-      creds_attributes: [
+      :org_id,
+      cred_attributes: [
         :label,
-        datadogs_attributes: [ :api_key, :application_key, :subdomain ],
-        sendgrids_attributes: [ :api_key, :subuser ]
+        datadog_attributes: [ :api_key, :application_key, :subdomain ],
+        sendgrid_attributes: [ :api_key, :subuser ]
         ]
-      ]
     )
   end
 end

--- a/app/models/connection.rb
+++ b/app/models/connection.rb
@@ -1,8 +1,8 @@
 class Connection < ApplicationRecord
   belongs_to :app
   belongs_to :org
-  has_many :creds
+  has_one :cred
   has_many :accounts
 
-  accepts_nested_attributes_for :creds
+  accepts_nested_attributes_for :cred
 end

--- a/app/models/cred.rb
+++ b/app/models/cred.rb
@@ -2,4 +2,6 @@ class Cred < ApplicationRecord
   belongs_to :connection
   has_many :datadogs
   has_many :sendgrids
+
+  accepts_nested_attributes_for :datadogs, :sendgrids
 end

--- a/app/models/cred.rb
+++ b/app/models/cred.rb
@@ -1,7 +1,7 @@
 class Cred < ApplicationRecord
   belongs_to :connection
-  has_many :datadogs
-  has_many :sendgrids
+  has_one :datadog
+  has_one :sendgrid
 
-  accepts_nested_attributes_for :datadogs, :sendgrids
+  accepts_nested_attributes_for :datadog, :sendgrid
 end

--- a/app/models/datadog.rb
+++ b/app/models/datadog.rb
@@ -1,3 +1,7 @@
 class Datadog < ApplicationRecord
   belongs_to :cred
+
+  validates :api_key, presence: true
+  validates :application_key, presence: true
+  validates :subdomain, presence: true
 end

--- a/app/models/sendgrid.rb
+++ b/app/models/sendgrid.rb
@@ -1,3 +1,6 @@
 class Sendgrid < ApplicationRecord
   belongs_to :cred
+
+  validates :api_key, presence: true
+  validates :subuser, presence: true
 end

--- a/app/views/connections/new.html.erb
+++ b/app/views/connections/new.html.erb
@@ -1,7 +1,19 @@
 <%= form_with(model: @conn, url:org_app_connections_url) do |f| %>
   <h3>Connecting to <%= @app.name %></h3>
+  <% if @conn.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(@conn.errors.count, "error") %> prohibited this connection from being saved:</h2>
+      <ul>
+        <% @conn.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
   
-  <%= f.fields_for :creds do |cred_fields| %>
+  <%= f.hidden_field :app_id, value: params[:app_id]  %>
+  <%= f.hidden_field :org_id, value: params[:org_id]  %>
+  <%= f.fields_for :cred do |cred_fields| %>
     <div class="cred">
       <%= cred_fields.label :label %>  
       <%= cred_fields.text_field :label %>  

--- a/app/views/connections/new.html.erb
+++ b/app/views/connections/new.html.erb
@@ -1,0 +1,19 @@
+<%= form_with(model: @conn, url:org_app_connections_url) do |f| %>
+  <h3>Connecting to <%= @app.name %></h3>
+  
+  <%= f.fields_for :creds do |cred_fields| %>
+    <div class="cred">
+      <%= cred_fields.label :label %>  
+      <%= cred_fields.text_field :label %>  
+      <div class="dynamic-fields">
+        <% if @app.name == 'Datadog' %>
+          <%= render 'shared/datadog_fields', cred_fields: cred_fields %>
+        <% elsif @app.name == 'Sendgrid' %>
+          <%= render 'shared/sendgrid_fields', cred_fields: cred_fields %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+  
+  <%= f.submit %>
+<% end %>

--- a/app/views/shared/_datadog_fields.html.erb
+++ b/app/views/shared/_datadog_fields.html.erb
@@ -1,8 +1,8 @@
-<%= cred_fields.fields_for :datadogs do |datadogs_field| %>
-  <%= datadogs_field.label :api_key, "API Key" %>  
-  <%= datadogs_field.text_field :api_key %>
-  <%= datadogs_field.label :application_key, "Application Key" %>  
-  <%= datadogs_field.text_field :application_key %>
-  <%= datadogs_field.label :subdomain, "Subdomain" %>  
-  <%= datadogs_field.text_field :subdomain %>
+<%= cred_fields.fields_for :datadog do |datadog_fields| %>
+  <%= datadog_fields.label :api_key, "API Key" %>  
+  <%= datadog_fields.text_field :api_key %>
+  <%= datadog_fields.label :application_key, "Application Key" %>  
+  <%= datadog_fields.text_field :application_key %>
+  <%= datadog_fields.label :subdomain, "Subdomain" %>  
+  <%= datadog_fields.text_field :subdomain %>
 <% end %>

--- a/app/views/shared/_datadog_fields.html.erb
+++ b/app/views/shared/_datadog_fields.html.erb
@@ -1,0 +1,8 @@
+<%= cred_fields.fields_for :datadogs do |datadogs_field| %>
+  <%= datadogs_field.label :api_key, "API Key" %>  
+  <%= datadogs_field.text_field :api_key %>
+  <%= datadogs_field.label :application_key, "Application Key" %>  
+  <%= datadogs_field.text_field :application_key %>
+  <%= datadogs_field.label :subdomain, "Subdomain" %>  
+  <%= datadogs_field.text_field :subdomain %>
+<% end %>

--- a/app/views/shared/_sendgrid_fields.html.erb
+++ b/app/views/shared/_sendgrid_fields.html.erb
@@ -1,6 +1,6 @@
-<%= cred_fields.fields_for :sendgrids do |sendgrids_field| %>
-  <%= sendgrids_field.label :api_key, "API Key" %>  
-  <%= sendgrids_field.text_field :api_key %>
-  <%= sendgrids_field.label :subuser, "Subuser" %>  
-  <%= sendgrids_field.text_field :subuser %>
+<%= cred_fields.fields_for :sendgrid do |sendgrid_fields| %>
+  <%= sendgrid_fields.label :api_key, "API Key" %>  
+  <%= sendgrid_fields.text_field :api_key %>
+  <%= sendgrid_fields.label :subuser, "Subuser" %>  
+  <%= sendgrid_fields.text_field :subuser %>
 <% end %>

--- a/app/views/shared/_sendgrid_fields.html.erb
+++ b/app/views/shared/_sendgrid_fields.html.erb
@@ -1,0 +1,6 @@
+<%= cred_fields.fields_for :sendgrids do |sendgrids_field| %>
+  <%= sendgrids_field.label :api_key, "API Key" %>  
+  <%= sendgrids_field.text_field :api_key %>
+  <%= sendgrids_field.label :subuser, "Subuser" %>  
+  <%= sendgrids_field.text_field :subuser %>
+<% end %>


### PR DESCRIPTION
This PR introduces a new `ConnectionsController` to manage connections for different applications, adds nested attributes handling in the `Cred` model, and updates the views to support dynamic form fields for `Datadog` and `Sendgrid` credentials.

### Controller and Model Changes:

* [`app/controllers/connections_controller.rb`](diffhunk://#diff-6d8f36802cc5d0578eb16da89069ddaf610189c6f2e3857e9784eeb1aa0ada4aR1-R38): Created a new `ConnectionsController` with actions to handle connections and added strong parameters for nested attributes.
* [`app/models/cred.rb`](diffhunk://#diff-925bc5bcb5b8ed9aafbbedb7433a95bd56edcc6a7c86437cfeb4801e1f65cd76R5-R6): Added `accepts_nested_attributes_for` to handle nested attributes for `datadogs` and `sendgrids`.

### View Changes:

* [`app/views/connections/new.html.erb`](diffhunk://#diff-fc4b8901103af7ac70bd58571660116c4f9a359ca2898a8c6b086fd22da9a2ebR1-R19): Updated the new connection form to dynamically render fields based on the application type (`Datadog` or `Sendgrid`).
* [`app/views/shared/_datadog_fields.html.erb`](diffhunk://#diff-13cb9ce35b274b8f712b7f3faead72a3e5fef9d5ec1c3eb455094bb5281ea79aR1-R8): Added partial to render fields specific to `Datadog` credentials.
* [`app/views/shared/_sendgrid_fields.html.erb`](diffhunk://#diff-6f0dc163b6b1d9c50bbf62de163fdddd657e9c533656f0c3f12a3ea567b09d28R1-R6): Added partial to render fields specific to `Sendgrid` credentials.