### PR TITLE
refactor: Cleaning up validations

### DIFF
--- a/app/models/connection.rb
+++ b/app/models/connection.rb
@@ -1,5 +1,4 @@
 class Connection < ApplicationRecord
-  include ActiveModel::Validations
   belongs_to :app
   belongs_to :org
   has_one :cred

--- a/app/models/datadog_validator.rb
+++ b/app/models/datadog_validator.rb
@@ -1,15 +1,15 @@
 class DatadogValidator < ActiveModel::Validator
   def validate(record)
-      if record.cred.datadog.api_key.present? && record.cred.datadog.application_key.present? && record.cred.datadog.subdomain.present?
+      if record.api_key.present? && record.application_key.present? && record.subdomain.present?
             conn = Faraday.new(
               url: "https://api.datadoghq.com",
             )
             response = conn.get do |req|
               req.url "/api/v1/validate"
               req.headers["Content-Type"] = "application/json"
-              req.headers["DD_API_KEY"] = "#{record.cred.datadog.api_key}"
-              req.headers["DD_APP_KEY"] = "#{record.cred.datadog.application_key}"
-              req.headers["DD_SITE"] = "#{record.cred.datadog.subdomain}"
+              req.headers["DD_API_KEY"] = "#{record.api_key}"
+              req.headers["DD_APP_KEY"] = "#{record.application_key}"
+              req.headers["DD_SITE"] = "#{record.subdomain}"
             end
       
             if response.status != 200


### PR DESCRIPTION
This pull request includes changes to the `app/models/connection.rb` and `app/models/datadog_validator.rb` files to simplify the validation logic and remove unnecessary code.

Code simplification:

* [`app/models/connection.rb`](diffhunk://#diff-f9f6585cf6adc8b4e2b4cac7be10caebf7c58e516f8cb2de1eca257a4370b035L2): Removed the inclusion of `ActiveModel::Validations` as it was not being used.
* [`app/models/datadog_validator.rb`](diffhunk://#diff-bc96e798aa2cf3d7aa781323c491ee9c9fdb7148e2a7b1805aa790ea0895856cL3-R12): Simplified the validation logic by directly accessing `api_key`, `application_key`, and `subdomain` attributes instead of nested attributes within `cred.datadog`.