### PR TITLE
feat: Finish sqs listener job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,5 @@ gem "google-api-client", "~> 0.53.0"
 gem "aws-sdk-rails", "~> 5.0"
 
 gem "aws-sdk-sqs", "~> 1.89"
+
+gem "shoryuken", "~> 6.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,6 +347,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    shoryuken (6.2.1)
+      aws-sdk-core (>= 2)
+      concurrent-ruby
+      thor
     signet (0.19.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -434,6 +438,7 @@ DEPENDENCIES
   rspec-rails (~> 7.0)
   rubocop-rails-omakase
   selenium-webdriver
+  shoryuken (~> 6.2)
   solid_queue (~> 1.0)
   sprockets-rails
   stimulus-rails

--- a/app/jobs/sqs_listener_job.rb
+++ b/app/jobs/sqs_listener_job.rb
@@ -1,0 +1,16 @@
+class SqsListenerJob
+  include Shoryuken::Worker
+
+  shoryuken_options queue: "http://localhost:4566/000000000000/response-queue", auto_delete: true
+
+  def perform(sqs_msg, body)
+    employees_attributes = JSON.parse(body).map do |emp|
+      {
+        org_id: emp['org_id'], 
+        email: emp['email'],
+        name: emp['name']
+      }
+    end
+    Employee.upsert_all(employees_attributes)
+  end
+end

--- a/app/models/google_workspace.rb
+++ b/app/models/google_workspace.rb
@@ -5,10 +5,10 @@ class GoogleWorkspace < ApplicationRecord
 
   validates :refresh_token, presence: true
   after_save_commit do
-    # GoogleWorkspaceSyncJob.perform_later(self.id)
-    region = 'us-east-1'
+    region = Rails.application.credentials.dig(:aws,:region)
     request_queue_name = 'request-queue'
     message_body = {
+      org_id: Current.user.org.id,
       client_id: Rails.application.credentials.dig(:google, :client_id),
       client_secret: Rails.application.credentials.dig(:google, :client_secret),
       refresh_token: self.refresh_token


### PR DESCRIPTION
This pull request introduces a new job to process SQS messages and updates the Google Workspace model to dynamically fetch AWS region and include organization ID in the message body. Additionally, a new gem is added to the Gemfile to support the changes.

### New functionality:

* **SQS Listener Job**:
  * Added `SqsListenerJob` class to process messages from an SQS queue. It includes the `Shoryuken::Worker` module and defines a `perform` method to parse and upsert employee data.

### Configuration updates:

* **Gemfile**:
  * Added the `shoryuken` gem to support the SQS listener functionality.

### Model updates:

* **Google Workspace Model**:
  * Updated the `GoogleWorkspace` model to dynamically fetch the AWS region from credentials and include the organization ID in the message body when saving.