### PR TITLE
Employee accessed app display

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,5 @@ gem "google-api-client", "~> 0.53.0"
 gem "aws-sdk-rails", "~> 5.0"
 
 gem "aws-sdk-sqs", "~> 1.89"
+
+gem "shoryuken", "~> 6.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,6 +347,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    shoryuken (6.2.1)
+      aws-sdk-core (>= 2)
+      concurrent-ruby
+      thor
     signet (0.19.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -434,6 +438,7 @@ DEPENDENCIES
   rspec-rails (~> 7.0)
   rubocop-rails-omakase
   selenium-webdriver
+  shoryuken (~> 6.2)
   solid_queue (~> 1.0)
   sprockets-rails
   stimulus-rails

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -1,0 +1,11 @@
+class EmployeesController < ApplicationController
+  def index
+    @org = Current.user.org
+    @employees = @org.employees
+  end
+
+  def show
+    @employee = Employee.find(params[:id])
+    @apps = App.joins(connections: :accounts).where(accounts: { email: @employee.email }).distinct
+  end
+end

--- a/app/jobs/datadog_sync_job.rb
+++ b/app/jobs/datadog_sync_job.rb
@@ -3,7 +3,7 @@ class DatadogSyncJob < ApplicationJob
 
   def perform(job)
       datadog_credential = Datadog.find(job[:id])
-      credential = Cred.find_by(credable_id: job[:id])
+      credential = Cred.datadogs.find_by(credable_id: job[:id])
       response = DatadogServices::ListUsers.new(datadog_credential).call(
         pagesize: job[:pagesize],
         page: job[:page]

--- a/app/jobs/dropbox_sync_job.rb
+++ b/app/jobs/dropbox_sync_job.rb
@@ -3,7 +3,7 @@ class DropboxSyncJob < ApplicationJob
 
   def perform(id, limit, include_removed = false)
     dropbox_credential = Dropbox.find(id)
-    credential = Cred.find_by(credable_id: id)
+    credential = Cred.dropboxes.find_by(credable_id: id)
     access_token = DropboxServices::GetTokens.new.get_access_token(dropbox_credential.refresh_token)
     fetch_members_service = DropboxServices::FetchMembers.new
     response = fetch_members_service.fetch_members(access_token: access_token, limit: limit, include_removed: include_removed)

--- a/app/jobs/sqs_listener_job.rb
+++ b/app/jobs/sqs_listener_job.rb
@@ -1,0 +1,16 @@
+class SqsListenerJob
+  include Shoryuken::Worker
+
+  shoryuken_options queue: "http://localhost:4566/000000000000/response-queue", auto_delete: true
+
+  def perform(sqs_msg, body)
+    employees_attributes = JSON.parse(body).map do |emp|
+      {
+        org_id: emp['org_id'], 
+        email: emp['email'],
+        name: emp['name']
+      }
+    end
+    Employee.upsert_all(employees_attributes)
+  end
+end

--- a/app/jobs/sqs_listener_job.rb
+++ b/app/jobs/sqs_listener_job.rb
@@ -1,7 +1,7 @@
 class SqsListenerJob
   include Shoryuken::Worker
 
-  shoryuken_options queue: "http://localhost:4566/000000000000/response-queue", auto_delete: true
+  shoryuken_options queue: Rails.application.credentials.dig(:aws,:response_queue_url), auto_delete: true
 
   def perform(sqs_msg, body)
     employees_attributes = JSON.parse(body).map do |emp|
@@ -12,5 +12,6 @@ class SqsListenerJob
       }
     end
     Employee.upsert_all(employees_attributes)
+    
   end
 end

--- a/app/models/google_workspace.rb
+++ b/app/models/google_workspace.rb
@@ -5,10 +5,10 @@ class GoogleWorkspace < ApplicationRecord
 
   validates :refresh_token, presence: true
   after_save_commit do
-    # GoogleWorkspaceSyncJob.perform_later(self.id)
-    region = 'us-east-1'
+    region = Rails.application.credentials.dig(:aws,:region)
     request_queue_name = 'request-queue'
     message_body = {
+      org_id: Current.user.org.id,
       client_id: Rails.application.credentials.dig(:google, :client_id),
       client_secret: Rails.application.credentials.dig(:google, :client_secret),
       refresh_token: self.refresh_token

--- a/app/models/google_workspace.rb
+++ b/app/models/google_workspace.rb
@@ -6,7 +6,7 @@ class GoogleWorkspace < ApplicationRecord
   validates :refresh_token, presence: true
   after_save_commit do
     region = Rails.application.credentials.dig(:aws,:region)
-    request_queue_name = 'request-queue'
+    request_queue_name = Rails.application.credentials.dig(:aws,:request_queue_name)
     message_body = {
       org_id: Current.user.org.id,
       client_id: Rails.application.credentials.dig(:google, :client_id),

--- a/app/services/google_workspace_services/get_tokens.rb
+++ b/app/services/google_workspace_services/get_tokens.rb
@@ -15,7 +15,6 @@ module GoogleWorkspaceServices
     def get_refresh_token(auth_code, oauth_callback_url)
         auth_client.code = auth_code
         auth_client.fetch_access_token!
-        # abort
         auth_client.refresh_token
     end
 

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -1,0 +1,12 @@
+<h3> Employee List </h3>
+
+<%if @employees.length == 0%>
+<h3>None yet</h3>
+<%=link_to "Connect to Google Workspaces", "https://accounts.google.com/o/oauth2/auth?access_type=offline&client_id=275918590791-if8f6h40ithej7t591jq7gu3kavfsvn1.apps.googleusercontent.com&include_granted_scopes=true&redirect_uri=http://localhost:3000/oauth_callback/GoogleWorkspace&response_type=code&scope=https://www.googleapis.com/auth/admin.directory.user.readonly" %>
+<%else%>
+    <% @employees.each do |emp|%>
+        <li>
+            <%= link_to emp.name, employee_path(emp.id)%>
+        </li>
+    <%end%>
+<%end%>

--- a/app/views/employees/show.html.erb
+++ b/app/views/employees/show.html.erb
@@ -1,0 +1,12 @@
+<h3> <%=@employee.name%> </h3>
+<h4> <%=@employee.email%> </h4>
+<h2>Accessed Apps</h2>
+<% if @apps.length == 0%>
+<h5> None at the moment </h5>
+<% else %>
+<% @apps.each do |app|%>
+    <li>
+        <%= app.name %>
+    </li>
+<%end%>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,7 @@
         <%= link_to 'Dashboard', dashboard_path %>
         <%= link_to 'Apps', apps_path %>
         <%= link_to 'Connections', connections_path %>
+        <%= link_to 'Employees', employees_path %>
     </div>
     
     <%= yield %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :apps, only: [ :index ] do
       resources :connections, only: [ :new, :create ]
   end
+  resources :employees, only: [ :index, :show ]
   mount MissionControl::Jobs::Engine, at: "/jobs"
 
   get "oauth_callback/:app_name", to: "oauth#oauth_callback", as: :oauth_callback


### PR DESCRIPTION
This pull request introduces several new features and improvements, including the addition of a new `EmployeesController`, integration of Shoryuken for SQS processing, and updates to various job classes. The most important changes are summarized below:

### New Features:
* **Employees Controller and Views**:
  - Added `EmployeesController` with `index` and `show` actions to manage employee records.
  - Created views for listing employees and displaying individual employee details. [[1]](diffhunk://#diff-130d8c124ea154d8ddccbc413adca4df158e94d386b04306db6d7fef445db6f6R1-R12) [[2]](diffhunk://#diff-d7f5b03f568d7e42d51940033671ff7280886a0fbafce63e54307dcc19876a1dR1-R12)
  - Updated routes to include `employees` resource.
  - Added a link to the Employees page in the application layout.

* **Shoryuken Integration**:
  - Added `shoryuken` gem to the `Gemfile` for SQS processing.
  - Created `SqsListenerJob` to process SQS messages and upsert employee records.

### Configuration Updates:
* **Google Workspace Model**:
  - Updated to use credentials from Rails application credentials for AWS region and request queue name.

### Code Cleanup:
* **Google Workspace Services**:
  - Removed commented-out code in `get_refresh_token` method.